### PR TITLE
로그인(세션) 기능 구현

### DIFF
--- a/src/main/java/com/github/thundermarket/thundermarket/controller/UserController.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/controller/UserController.java
@@ -3,6 +3,7 @@ package com.github.thundermarket.thundermarket.controller;
 import com.github.thundermarket.thundermarket.Util.Email;
 import com.github.thundermarket.thundermarket.domain.User;
 import com.github.thundermarket.thundermarket.service.UserService;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,5 +32,14 @@ public class UserController {
             return new ResponseEntity<>(Email.NOT_VALID_EMAIL_MESSAGE, HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>(userService.join(user), HttpStatus.OK);
+    }
+
+    @PostMapping("/auth/login")
+    public ResponseEntity<?> login(@RequestBody User user, HttpSession session) {
+        if(!userService.checkPassword(user)) {
+            return new ResponseEntity<>("Invalid credentials", HttpStatus.UNAUTHORIZED);
+        }
+        session.setAttribute("user", user.getEmail());
+        return new ResponseEntity<>("Login successful", HttpStatus.OK);
     }
 }

--- a/src/main/java/com/github/thundermarket/thundermarket/controller/UserController.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/controller/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
         return new ResponseEntity<>(userService.join(user), HttpStatus.OK);
     }
 
-    @PostMapping("/auth/login")
+    @PostMapping("/api/v1/auth/login")
     public ResponseEntity<?> login(@RequestBody User user, HttpSession session) {
         if(!userService.checkPassword(user)) {
             return new ResponseEntity<>("Invalid credentials", HttpStatus.UNAUTHORIZED);
@@ -41,7 +41,7 @@ public class UserController {
         return new ResponseEntity<>("Login successful", HttpStatus.OK);
     }
 
-    @GetMapping("/auth/mypage")
+    @GetMapping("/api/v1/auth/mypage")
     public ResponseEntity<?> mypage(HttpSession session) {
         String userEmail = (String) session.getAttribute("userEmail");
         if (userEmail == null) {

--- a/src/main/java/com/github/thundermarket/thundermarket/controller/UserController.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/controller/UserController.java
@@ -9,8 +9,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 public class UserController {
 
@@ -39,7 +37,16 @@ public class UserController {
         if(!userService.checkPassword(user)) {
             return new ResponseEntity<>("Invalid credentials", HttpStatus.UNAUTHORIZED);
         }
-        session.setAttribute("user", user.getEmail());
+        session.setAttribute("userEmail", user.getEmail());
         return new ResponseEntity<>("Login successful", HttpStatus.OK);
+    }
+
+    @GetMapping("/auth/mypage")
+    public ResponseEntity<?> mypage(HttpSession session) {
+        String userEmail = (String) session.getAttribute("userEmail");
+        if (userEmail == null) {
+            return new ResponseEntity<>("Unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+        return new ResponseEntity<>("Hello, " + userEmail, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/github/thundermarket/thundermarket/controller/UserController.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
 
     @PostMapping("/api/v1/auth/login")
     public ResponseEntity<?> login(@RequestBody User user, HttpSession session) {
-        if(!userService.checkPassword(user)) {
+        if(!userService.checkCredential(user)) {
             return new ResponseEntity<>("Invalid credentials", HttpStatus.UNAUTHORIZED);
         }
         session.setAttribute("userEmail", user.getEmail());

--- a/src/main/java/com/github/thundermarket/thundermarket/service/UserService.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/service/UserService.java
@@ -25,7 +25,7 @@ public class UserService {
         return userRepository.findAll();
     }
 
-    public boolean checkPassword(User user) {
+    public boolean checkCredential(User user) {
         User validUser = userRepository.findByEmailAndPassword(user.getEmail(), user.getPassword());
         return validUser != null;
     }

--- a/src/main/java/com/github/thundermarket/thundermarket/service/UserService.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/service/UserService.java
@@ -24,4 +24,9 @@ public class UserService {
     public List<User> findAllUsers() {
         return userRepository.findAll();
     }
+
+    public boolean checkPassword(User user) {
+        User validUser = userRepository.findByEmailAndPassword(user.getEmail(), user.getPassword());
+        return validUser != null;
+    }
 }

--- a/src/test/java/com/github/thundermarket/thundermarket/UserControllerTest.java
+++ b/src/test/java/com/github/thundermarket/thundermarket/UserControllerTest.java
@@ -11,8 +11,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -69,5 +68,54 @@ public class UserControllerTest {
         mockMvc.perform(get("/api/v1/users")
                         .contentType("application/json"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void 로그인_성공() throws Exception {
+        String email = "test01@email.com";
+        String password = "password";
+        User user = new User(email, password);
+
+        String userJson = objectMapper.writeValueAsString(user);
+
+        mockMvc.perform(post("/auth/join")
+                        .contentType("application/json")
+                        .content(userJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(email))
+                .andExpect(jsonPath("$.password").value(password));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType("application/json")
+                        .content(userJson))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Login successful"));
+    }
+
+    @Test
+    public void 로그인_실패() throws Exception {
+        String email = "test01@email.com";
+        String password = "password";
+        String wrongPassword = "wrong";
+        User user = new User(email, password);
+
+        String userJson = objectMapper.writeValueAsString(user);
+
+        mockMvc.perform(post("/auth/join")
+                        .contentType("application/json")
+                        .content(userJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(email))
+                .andExpect(jsonPath("$.password").value(password));
+
+
+        User wrongUser = new User(email, wrongPassword);
+        String wrongUserJson = objectMapper.writeValueAsString(wrongUser);
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType("application/json")
+                        .content(wrongUserJson))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string("Invalid credentials"));
     }
 }

--- a/src/test/java/com/github/thundermarket/thundermarket/UserControllerTest.java
+++ b/src/test/java/com/github/thundermarket/thundermarket/UserControllerTest.java
@@ -1,6 +1,5 @@
 package com.github.thundermarket.thundermarket;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.thundermarket.thundermarket.domain.User;
 import com.github.thundermarket.thundermarket.repository.UserRepository;
@@ -74,20 +73,16 @@ public class UserControllerTest {
 
     @Test
     public void 로그인_성공() throws Exception {
-        String email = "test01@email.com";
-        String password = "password";
-        User user = new User(email, password);
+        User user = createUser("test01@email.com", "password");
 
         String userJson = objectMapper.writeValueAsString(user);
 
-        mockMvc.perform(post("/auth/join")
+        mockMvc.perform(post("/api/v1/auth/join")
                         .contentType("application/json")
                         .content(userJson))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.email").value(email))
-                .andExpect(jsonPath("$.password").value(password));
+                .andExpect(status().isOk());
 
-        mockMvc.perform(post("/auth/login")
+        mockMvc.perform(post("/api/v1/auth/login")
                         .contentType("application/json")
                         .content(userJson))
                 .andExpect(status().isOk())
@@ -96,25 +91,20 @@ public class UserControllerTest {
 
     @Test
     public void 로그인_실패() throws Exception {
-        String email = "test01@email.com";
-        String password = "password";
-        String wrongPassword = "wrong";
-        User user = new User(email, password);
+        User user = createUser("test01@email.com", "password");
 
         String userJson = objectMapper.writeValueAsString(user);
 
-        mockMvc.perform(post("/auth/join")
+        mockMvc.perform(post("/api/v1/auth/join")
                         .contentType("application/json")
                         .content(userJson))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.email").value(email))
-                .andExpect(jsonPath("$.password").value(password));
+                .andExpect(status().isOk());
 
 
-        User wrongUser = new User(email, wrongPassword);
+        User wrongUser = createUser("test01@email.com", "wrong");
         String wrongUserJson = objectMapper.writeValueAsString(wrongUser);
 
-        mockMvc.perform(post("/auth/login")
+        mockMvc.perform(post("/api/v1/auth/login")
                         .contentType("application/json")
                         .content(wrongUserJson))
                 .andExpect(status().isUnauthorized())
@@ -123,58 +113,49 @@ public class UserControllerTest {
 
     @Test
     public void 마이페이지_조회_성공() throws Exception {
-        String email = "test01@email.com";
-        String password = "password";
-        User user = new User(email, password);
+        User user = createUser("test01@email.com", "password");
 
         String userJson = objectMapper.writeValueAsString(user);
 
-        mockMvc.perform(post("/auth/join")
+        mockMvc.perform(post("/api/v1/auth/join")
                         .contentType("application/json")
                         .content(userJson))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.email").value(email))
-                .andExpect(jsonPath("$.password").value(password));
+                .andExpect(status().isOk());
 
         MockHttpSession session = new MockHttpSession();
 
-        mockMvc.perform(post("/auth/login")
+        mockMvc.perform(post("/api/v1/auth/login")
                         .contentType("application/json")
                         .content(userJson)
                         .session(session))
                 .andExpect(status().isOk())
                 .andExpect(content().string("Login successful"));
 
-        mockMvc.perform(get("/auth/mypage")
+        mockMvc.perform(get("/api/v1/auth/mypage")
                         .contentType("application/json")
                         .session(session))
-                .andExpect(status().isOk())
-                .andExpect(content().string("Hello, " + email));
+                .andExpect(status().isOk());
     }
 
     @Test
     public void 마이페이지_조회_실패() throws Exception {
-        String email = "test01@email.com";
-        String password = "password";
-        User user = new User(email, password);
+        User user = createUser("test01@email.com", "password");
 
         String userJson = objectMapper.writeValueAsString(user);
 
-        mockMvc.perform(post("/auth/join")
+        mockMvc.perform(post("/api/v1/auth/join")
                         .contentType("application/json")
                         .content(userJson))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.email").value(email))
-                .andExpect(jsonPath("$.password").value(password));
+                .andExpect(status().isOk());
 
 
-        mockMvc.perform(post("/auth/login")
+        mockMvc.perform(post("/api/v1/auth/login")
                         .contentType("application/json")
                         .content(userJson))
                 .andExpect(status().isOk())
                 .andExpect(content().string("Login successful"));
 
-        mockMvc.perform(get("/auth/mypage")
+        mockMvc.perform(get("/api/v1/auth/mypage")
                         .contentType("application/json"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(content().string("Unauthorized"));


### PR DESCRIPTION
## 관련 Issue
[#8](https://github.com/f-lab-edu/thunder-market/issues/8)
</br></br>

## 작업 내용
### 로그인 기능 구현
- HttpSession을 사용해 로그인 성공 시 세션을 쿠키에 담아 반환하고, 마이페이지에 접근 시 세션 유무를 체크합니다.
</br></br>

## 정상 동작 테스트 방법
UserControllerTest 실행
또는 API 호출

회원가입
```java
curl --location 'localhost:8080/auth/join' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "test01@email.com",
    "password": "password"
}'
```

로그인 (세션 획득)
```java
curl --location 'localhost:8080/auth/login' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "test01@email.com",
    "password": "password"
}'
```

마이페이지 조회
```java
curl --location 'localhost:8080/auth/mypage' \
--header 'Cookie: JSESSIONID={sessionID}'
```

</br></br>


## 참고(선택 사항)
고민되는 부분

1. UserController 안에 /users, /auth 두가지 endpoint가 있는데 분리하는게 좋을지
2. 테스트코드에 각 테스트를 독립적으로 수행하기 위해 회원가입, 로그인이 많이 반복되는데 함수로 추출하는게 좋을지, 아니면 테스트코드는 독립적이어도 문제되지 않으니 그대로 두는게 나을지..
</br></br>
