### PR TITLE
JDBC를 통해 MySQL에 접근하도록 변경

### DIFF
--- a/src/main/java/com/github/thundermarket/thundermarket/config/RepositoryConfig.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/config/RepositoryConfig.java
@@ -1,0 +1,29 @@
+package com.github.thundermarket.thundermarket.config;
+
+import com.github.thundermarket.thundermarket.repository.MySQLUserRepository;
+import com.github.thundermarket.thundermarket.repository.UserRepository;
+import com.github.thundermarket.thundermarket.service.UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class RepositoryConfig {
+
+    private final DataSource dataSource;
+
+    public RepositoryConfig(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Bean
+    public UserService userService() {
+        return new UserService(userRepository());
+    }
+
+    @Bean
+    public UserRepository userRepository() {
+        return new MySQLUserRepository(dataSource);
+    }
+}

--- a/src/main/java/com/github/thundermarket/thundermarket/repository/MySQLUserRepository.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/repository/MySQLUserRepository.java
@@ -1,0 +1,119 @@
+package com.github.thundermarket.thundermarket.repository;
+
+import com.github.thundermarket.thundermarket.domain.User;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class MySQLUserRepository implements UserRepository {
+
+    private final DataSource dataSource;
+
+    @Autowired
+    public MySQLUserRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    private Connection getConnection() {
+        return DataSourceUtils.getConnection(dataSource);
+    }
+
+    private void releaseConnection(Connection conn) {
+        DataSourceUtils.releaseConnection(conn, dataSource);
+    }
+
+    @Override
+    public User save(User user) {
+        String sql = "INSERT INTO users (email, password) VALUES (?, ?)";
+        Connection conn = null;
+
+        try {
+            conn = getConnection();
+            try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+                ps.setString(1, user.getEmail());
+                ps.setString(2, user.getPassword());
+                int affectedRows = ps.executeUpdate();
+
+                if (affectedRows == 0) {
+                    throw new RuntimeException("Create user failed, no affectedRows");
+                }
+
+                try (ResultSet generatedKeys = ps.getGeneratedKeys()) {
+                    if (!generatedKeys.next()) {
+                        throw new RuntimeException("Create user failed, no generatedKeys");
+                    }
+                    user.setId(generatedKeys.getLong(1));
+                }
+                return user;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Create user failed", e);
+        } finally {
+            releaseConnection(conn);
+        }
+    }
+
+    @Override
+    public List<User> findAll() {
+        String sql = "SELECT * FROM users";
+        Connection conn = null;
+
+        try {
+            conn = getConnection();
+            try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+                ResultSet resultSet = ps.executeQuery();
+                List<User> users = new ArrayList<>();
+
+                while (resultSet.next()) {
+                    User user = new User();
+                    user.setId(resultSet.getLong("id"));
+                    user.setEmail(resultSet.getString("email"));
+                    user.setPassword(resultSet.getString("password"));
+                    users.add(user);
+                }
+                return users;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Find all users failed", e);
+        } finally {
+            releaseConnection(conn);
+        }
+    }
+
+    @Override
+    public User findByEmailAndPassword(String email, String password) {
+        String sql = "SELECT * FROM users WHERE email = ? AND password = ?";
+        Connection conn = null;
+
+        try {
+            conn = getConnection();
+            try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+                ps.setString(1, email);
+                ps.setString(2, password);
+
+                try (ResultSet resultSet = ps.executeQuery()) {
+                    if (resultSet.next()) {
+                        User user = new User();
+                        user.setId(resultSet.getLong("id"));
+                        user.setEmail(resultSet.getString("email"));
+                        user.setPassword(resultSet.getString("password"));
+
+                        return user;
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Find by email and password failed", e);
+        } finally {
+            releaseConnection(conn);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/thundermarket/thundermarket/repository/MySQLUserRepository.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/repository/MySQLUserRepository.java
@@ -16,7 +16,6 @@ public class MySQLUserRepository implements UserRepository {
 
     private final DataSource dataSource;
 
-    @Autowired
     public MySQLUserRepository(DataSource dataSource) {
         this.dataSource = dataSource;
     }

--- a/src/main/java/com/github/thundermarket/thundermarket/service/UserService.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/service/UserService.java
@@ -3,7 +3,6 @@ package com.github.thundermarket.thundermarket.service;
 import com.github.thundermarket.thundermarket.domain.User;
 import com.github.thundermarket.thundermarket.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,7 +13,7 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Autowired
-    public UserService(@Qualifier("mySQLUserRepository") UserRepository userRepository) {
+    public UserService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
 

--- a/src/main/java/com/github/thundermarket/thundermarket/service/UserService.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/service/UserService.java
@@ -3,6 +3,7 @@ package com.github.thundermarket.thundermarket.service;
 import com.github.thundermarket.thundermarket.domain.User;
 import com.github.thundermarket.thundermarket.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,7 +14,7 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Autowired
-    public UserService(UserRepository userRepository) {
+    public UserService(@Qualifier("mySQLUserRepository") UserRepository userRepository) {
         this.userRepository = userRepository;
     }
 

--- a/src/test/java/com/github/thundermarket/thundermarket/UserControllerTest.java
+++ b/src/test/java/com/github/thundermarket/thundermarket/UserControllerTest.java
@@ -2,13 +2,13 @@ package com.github.thundermarket.thundermarket;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.thundermarket.thundermarket.domain.User;
-import com.github.thundermarket.thundermarket.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class UserControllerTest {
 
     @Autowired
@@ -23,9 +24,6 @@ public class UserControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @Autowired
-    UserRepository userRepository;
 
     private User createUser(String email, String password) {
         return new User(email, password);


### PR DESCRIPTION
## 관련 Issue
[#17](https://github.com/f-lab-edu/thunder-market/issues/17)
</br></br>

## 작업 내용
기존에 in memory로 작업한 [회원가입, 로그인, 전체 사용자 조회] 기능에 대해 JDBC, MySQL을 사용하는 구체 클래스를  추가하였습니다.
</br></br>

## 정상 동작 테스트 방법
application.properties 파일에 MySQL 접속 정보 설정한 뒤 테스트코드 실행
</br></br>


## 참고(선택 사항)
MySQL은 docker-compose.yml을 통해 로컬에서 구동할 수 있습니다. 관련 커밋 (https://github.com/f-lab-edu/thunder-market/commit/bf18cd4dd64555ed89b22420ddd63edb35c0445f)
</br></br>
