### PR TITLE
검색 필터 기능

### DIFF
--- a/src/main/java/com/github/thundermarket/thundermarket/controller/ProductController.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/controller/ProductController.java
@@ -38,4 +38,9 @@ public class ProductController {
                                                @RequestPart("video") MultipartFile video) throws IOException {
         return new ResponseEntity<>(productService.add(productRequest.toProduct(), productRequest.toProductDetail(), video), HttpStatus.OK);
     }
+
+    @GetMapping("/api/v1/products/filter")
+    public ResponseEntity<ProductsResponse> filteredProducts(@ModelAttribute ProductFilterRequest productFilterRequest) {
+        return new ResponseEntity<>(productService.filter(productFilterRequest), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/github/thundermarket/thundermarket/domain/ProductFilterRequest.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/domain/ProductFilterRequest.java
@@ -1,0 +1,75 @@
+package com.github.thundermarket.thundermarket.domain;
+
+import java.util.Objects;
+
+public class ProductFilterRequest {
+
+    private String name;
+    private int priceMin;
+    private int priceMax;
+    private String color;
+    private String purchaseDateMin;
+    private String purchaseDateMax;
+
+    public ProductFilterRequest(String name, int priceMin, int priceMax, String color, String purchaseDateMin, String purchaseDateMax) {
+        this.name = name;
+        this.priceMin = priceMin;
+        this.priceMax = priceMax;
+        this.color = color;
+        this.purchaseDateMin = purchaseDateMin;
+        this.purchaseDateMax = purchaseDateMax;
+    }
+
+    public static ProductFilterRequest of(String name, int priceMin, int priceMax, String color, String purchaseDateMin, String purchaseDateMax) {
+        return new ProductFilterRequest(name, priceMin, priceMax, color, purchaseDateMin, purchaseDateMax);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPriceMin() {
+        return priceMin;
+    }
+
+    public int getPriceMax() {
+        return priceMax;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public String getPurchaseDateMin() {
+        return purchaseDateMin;
+    }
+
+    public String getPurchaseDateMax() {
+        return purchaseDateMax;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProductFilterRequest that = (ProductFilterRequest) o;
+        return priceMin == that.priceMin && priceMax == that.priceMax && Objects.equals(name, that.name) && Objects.equals(color, that.color) && Objects.equals(purchaseDateMin, that.purchaseDateMin) && Objects.equals(purchaseDateMax, that.purchaseDateMax);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, priceMin, priceMax, color, purchaseDateMin, purchaseDateMax);
+    }
+
+    @Override
+    public String toString() {
+        return "ProductFilterRequest{" +
+                "name='" + name + '\'' +
+                ", priceMin=" + priceMin +
+                ", priceMax=" + priceMax +
+                ", color='" + color + '\'' +
+                ", purchaseDateMin=" + purchaseDateMin +
+                ", purchaseDateMax=" + purchaseDateMax +
+                '}';
+    }
+}

--- a/src/main/java/com/github/thundermarket/thundermarket/domain/ProductsResponse.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/domain/ProductsResponse.java
@@ -16,6 +16,10 @@ public class ProductsResponse {
         this.limit = limit;
     }
 
+    public ProductsResponse(List<Product> products) {
+        this(products, null, 0);
+    }
+
     public List<Product> getProducts() {
         return products;
     }
@@ -26,6 +30,10 @@ public class ProductsResponse {
 
     public int getLimit() {
         return limit;
+    }
+
+    public static ProductsResponse of(List<Product> products) {
+        return new ProductsResponse(products);
     }
 
     public static ProductsResponse of(List<Product> products, Long newCursorId, int limit) {

--- a/src/main/java/com/github/thundermarket/thundermarket/repository/MySQLProductRepository.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/repository/MySQLProductRepository.java
@@ -107,7 +107,7 @@ public class MySQLProductRepository implements ProductRepository {
 
     @Override
     public List<Product> filterByProductOptions(ProductFilterRequest productFilterRequest) {
-        String sql = "SELECT * FROM products JOIN productDetails " +
+        String sql = "SELECT products.id, name, price, status FROM products JOIN productDetails " +
                 "ON products.id = productDetails.id " +
                 "WHERE products.name = ? " +
                 "AND products.price BETWEEN ? AND ? " +

--- a/src/main/java/com/github/thundermarket/thundermarket/repository/MySQLProductRepository.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/repository/MySQLProductRepository.java
@@ -1,7 +1,7 @@
 package com.github.thundermarket.thundermarket.repository;
 
 import com.github.thundermarket.thundermarket.domain.Product;
-import com.github.thundermarket.thundermarket.domain.User;
+import com.github.thundermarket.thundermarket.domain.ProductFilterRequest;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Repository;
 
@@ -65,31 +65,36 @@ public class MySQLProductRepository implements ProductRepository {
     @Override
     public List<Product> findAll(Long cursorId, int limit) {
         String sql = "SELECT * FROM products WHERE id > ? ORDER BY id DESC LIMIT ?";
+        Connection conn = null;
         List<Product> products = new ArrayList<>();
 
-        try (Connection conn = dataSource.getConnection();
-             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+        try {
+            conn = getConnection();
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
 
-            pstmt.setLong(1, cursorId);
-            pstmt.setInt(2, limit);
+                pstmt.setLong(1, cursorId);
+                pstmt.setInt(2, limit);
 
-            try (ResultSet rs = pstmt.executeQuery()) {
-                while (rs.next()) {
-                    long id = rs.getLong("id");
-                    String name = rs.getString("name");
-                    int price = rs.getInt("price");
-                    String status = rs.getString("status");
-                    products.add(new Product.Builder()
-                            .withId(id)
-                            .withName(name)
-                            .withPrice(price)
-                            .withStatus(status)
-                            .build()
-                    );
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    while (rs.next()) {
+                        long id = rs.getLong("id");
+                        String name = rs.getString("name");
+                        int price = rs.getInt("price");
+                        String status = rs.getString("status");
+                        products.add(new Product.Builder()
+                                .withId(id)
+                                .withName(name)
+                                .withPrice(price)
+                                .withStatus(status)
+                                .build()
+                        );
+                    }
                 }
             }
         } catch (SQLException e) {
             throw new RuntimeException("Fetching products failed", e);
+        } finally {
+            releaseConnection(conn);
         }
 
         return products;
@@ -98,5 +103,53 @@ public class MySQLProductRepository implements ProductRepository {
     @Override
     public void delete(Long id) {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public List<Product> filterByProductOptions(ProductFilterRequest productFilterRequest) {
+        String sql = "SELECT * FROM products JOIN productDetails " +
+                "ON products.id = productDetails.id " +
+                "WHERE products.name = ? " +
+                "AND products.price BETWEEN ? AND ? " +
+                "AND productDetails.color = ? " +
+                "AND productDetails.purchaseDate BETWEEN ? AND ?";
+
+        Connection conn = null;
+        List<Product> products = new ArrayList<>();
+
+        try {
+            conn = getConnection();
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+                pstmt.setString(1, productFilterRequest.getName());
+                pstmt.setInt(2, productFilterRequest.getPriceMin());
+                pstmt.setInt(3, productFilterRequest.getPriceMax());
+                pstmt.setString(4, productFilterRequest.getColor());
+                pstmt.setString(5, productFilterRequest.getPurchaseDateMin());
+                pstmt.setString(6, productFilterRequest.getPurchaseDateMax());
+
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    while (rs.next()) {
+                        long id = rs.getLong("id");
+                        String name = rs.getString("name");
+                        int price = rs.getInt("price");
+                        String status = rs.getString("status");
+                        products.add(new Product.Builder()
+                                .withId(id)
+                                .withName(name)
+                                .withPrice(price)
+                                .withStatus(status)
+                                .build()
+                        );
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Fetching products failed", e);
+        } finally {
+            releaseConnection(conn);
+        }
+
+        return products;
     }
 }

--- a/src/main/java/com/github/thundermarket/thundermarket/repository/ProductRepository.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/repository/ProductRepository.java
@@ -1,6 +1,7 @@
 package com.github.thundermarket.thundermarket.repository;
 
 import com.github.thundermarket.thundermarket.domain.Product;
+import com.github.thundermarket.thundermarket.domain.ProductFilterRequest;
 
 import java.util.List;
 
@@ -9,4 +10,5 @@ public interface ProductRepository {
     List<Product> findAll(Long cursorId, int limit);
     Product save(Product product);
     void delete(Long id);
+    List<Product> filterByProductOptions(ProductFilterRequest productFilterRequest);
 }

--- a/src/main/java/com/github/thundermarket/thundermarket/service/ProductService.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/service/ProductService.java
@@ -47,4 +47,8 @@ public class ProductService {
     public void delete(Long id) {
         productRepository.delete(id);
     }
+
+    public ProductsResponse filter(ProductFilterRequest productFilterRequest) {
+        return ProductsResponse.of(productRepository.filterByProductOptions(productFilterRequest));
+    }
 }

--- a/src/test/java/com/github/thundermarket/thundermarket/ProductServiceTest.java
+++ b/src/test/java/com/github/thundermarket/thundermarket/ProductServiceTest.java
@@ -6,6 +6,7 @@ import com.github.thundermarket.thundermarket.TestDouble.ProductDetailFakeReposi
 import com.github.thundermarket.thundermarket.TestDouble.ProductFakeRepository;
 import com.github.thundermarket.thundermarket.domain.Product;
 import com.github.thundermarket.thundermarket.domain.ProductDetail;
+import com.github.thundermarket.thundermarket.domain.ProductFilterRequest;
 import com.github.thundermarket.thundermarket.domain.ProductsResponse;
 import com.github.thundermarket.thundermarket.repository.FileStorage;
 import com.github.thundermarket.thundermarket.service.ProductService;
@@ -208,5 +209,23 @@ public class ProductServiceTest {
         // cursorId 0L, limit 1 일 때 다음 커서 id는 2여야 함
         products = productService.products(1L, 1);
         Assertions.assertThat(products.getCursorId()).isEqualTo(2);
+    }
+
+    @Test
+    public void 상품조회_상품옵션필터링() {
+        String name = "iPhone11";
+        int priceMin = 1000;
+        int priceMax = 300000;
+        String color = "white";
+        String purchaseDateMin = "2023-01-01";
+        String purchaseDateMax = "2024-07-17";
+        ProductService productService = new ProductService(productRepository, productDetailFakeRepository, fileStorage);
+        ProductFilterRequest productFilterRequest = ProductFilterRequest.of(name, priceMin, priceMax, color, purchaseDateMin, purchaseDateMax);
+
+        Product product = productService.filter(productFilterRequest).getProducts().getFirst();
+
+        Assertions.assertThat(product.getName()).isEqualTo(name);
+        Assertions.assertThat(product.getPrice()).isGreaterThanOrEqualTo(priceMin);
+        Assertions.assertThat(product.getPrice()).isLessThanOrEqualTo(priceMax);
     }
 }

--- a/src/test/java/com/github/thundermarket/thundermarket/TestDouble/ProductFakeRepository.java
+++ b/src/test/java/com/github/thundermarket/thundermarket/TestDouble/ProductFakeRepository.java
@@ -1,6 +1,7 @@
 package com.github.thundermarket.thundermarket.TestDouble;
 
 import com.github.thundermarket.thundermarket.domain.Product;
+import com.github.thundermarket.thundermarket.domain.ProductFilterRequest;
 import com.github.thundermarket.thundermarket.repository.ProductRepository;
 
 import java.util.ArrayList;
@@ -30,5 +31,16 @@ public class ProductFakeRepository implements ProductRepository {
     @Override
     public void delete(Long id) {
         products.remove(id.intValue());
+    }
+
+    @Override
+    public List<Product> filterByProductOptions(ProductFilterRequest productFilterRequest) {
+        save(new Product.Builder().withName("iPhone11").withPrice(290000).withStatus("판매중").build());
+
+        return products.stream()
+                .filter(p -> p.getName().equals(productFilterRequest.getName())
+                        && p.getPrice() >= productFilterRequest.getPriceMin()
+                        && p.getPrice() <= productFilterRequest.getPriceMax())
+                .toList();
     }
 }

--- a/src/test/resources/productFilterTest.sql
+++ b/src/test/resources/productFilterTest.sql
@@ -1,0 +1,7 @@
+INSERT INTO `products` (`id`, `name`, `price`, `status`)
+VALUES
+    (1, 'iPhone11', 200000, 'available');
+
+INSERT INTO `productDetails` (`id`, `color`, `productCondition`, `batteryCondition`, `cameraCondition`, `accessories`, `purchaseDate`, `warrantyDuration`, `tradeLocation`, `deliveryFee`, `videoFilePath`, `thumbnailFilePath`)
+VALUES
+    (1, 'white', 'New', 'Good', 'Good', 'Charger, Earphones', '2023-01-02', '12 months', 'Seoul', 5000, 'https://kr.object.ncloudstorage.com/thunder-market-bucket/video/video_3c03c215-e0d5-48cb-8029-d06337051e8a_5sec.mp4', 'https://kr.object.ncloudstorage.com/thunder-market-bucket/thumbnail/thumbnail_3c03c215-e0d5-48cb-8029-d06337051e8a.jpg');


### PR DESCRIPTION
## 관련 Issue
[#32](https://github.com/f-lab-edu/thunder-market/issues/32)
</br></br>

## 작업 내용
검색 필터 기능을 추가하였습니다.
</br></br>

## 정상 동작 테스트 방법
테스트 코드 실행 또는 curl
```python
curl --location 'localhost:8080/api/v1/products/filter?name=iPhone11&priceMin=1000&priceMax=300000&color=white&purchaseDateMin=2022-01-01&purchaseDateMax=2024-07-17' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--header 'Cookie: SESSION=$session'
```
</br></br>


## 참고(선택 사항)
Repository에 Connection을 가져오고, 반환하는 코드를 
`dataSource.getConnection();`, `DataSourceUtils.getConnection(dataSource);`
두가지를 혼용해서 쓰는 바람에 테스트 코드가 다른 경계 범위에서 동작하는 오류로 인해 많은 삽질이 있었습니다.
휴먼에러를 줄이기 위해 JDBC Template 도입을 고민하게 되었습니다.
</br></br>
