### PR TITLE
상품 게시글 제목 검색

### DIFF
--- a/src/main/java/com/github/thundermarket/thundermarket/controller/ProductController.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/controller/ProductController.java
@@ -43,4 +43,9 @@ public class ProductController {
     public ResponseEntity<ProductsResponse> filteredProducts(@ModelAttribute ProductFilterRequest productFilterRequest) {
         return new ResponseEntity<>(productService.filter(productFilterRequest), HttpStatus.OK);
     }
+
+    @GetMapping("/api/v1/products/keyword")
+    public ResponseEntity<ProductsResponse> keywordProducts(@RequestParam("keyword") String keyword) {
+        return new ResponseEntity<>(productService.searchTitleKeyword(keyword), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/github/thundermarket/thundermarket/domain/Product.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/domain/Product.java
@@ -10,6 +10,7 @@ public class Product {
 
     @Id
     private Long id;
+    private String title;
     private String name;
     private int price;
     private String status;
@@ -18,6 +19,10 @@ public class Product {
      * RestController에서 JSON 역직렬화 과정 중 ObjectMapper가 리플랙션을 사용하여 객체를 생성하기 위해 기본 생성자가 필요함
      */
     public Product() {
+    }
+
+    public String getTitle() {
+        return title;
     }
 
     public Long getId() {
@@ -38,6 +43,7 @@ public class Product {
 
     private Product(Builder builder) {
         this.id = builder.id;
+        this.title = builder.title;
         this.name = builder.name;
         this.price = builder.price;
         this.status = builder.status;
@@ -45,6 +51,7 @@ public class Product {
 
     public static class Builder {
         private Long id;
+        private String title;
         private String name;
         private int price;
         private String status;
@@ -54,6 +61,7 @@ public class Product {
 
         public Builder(Product product) {
             this.id = product.id;
+            this.title = product.title;
             this.name = product.name;
             this.price = product.price;
             this.status = product.status;
@@ -61,6 +69,11 @@ public class Product {
 
         public Builder withId(Long id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder withTitle(String title) {
+            this.title = title;
             return this;
         }
 
@@ -89,18 +102,19 @@ public class Product {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Product product = (Product) o;
-        return price == product.price && Objects.equals(id, product.id) && Objects.equals(name, product.name) && Objects.equals(status, product.status);
+        return price == product.price && Objects.equals(id, product.id) && Objects.equals(title, product.title) && Objects.equals(name, product.name) && Objects.equals(status, product.status);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, price, status);
+        return Objects.hash(id, title, name, price, status);
     }
 
     @Override
     public String toString() {
         return "Product{" +
                 "id=" + id +
+                ", title='" + title + '\'' +
                 ", name='" + name + '\'' +
                 ", price=" + price +
                 ", status='" + status + '\'' +

--- a/src/main/java/com/github/thundermarket/thundermarket/domain/ProductRequest.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/domain/ProductRequest.java
@@ -17,6 +17,7 @@ public class ProductRequest {
 
     public Product toProduct() {
         return new Product.Builder()
+                .withTitle(product.getTitle())
                 .withName(product.getName())
                 .withPrice(product.getPrice())
                 .withStatus(product.getStatus())

--- a/src/main/java/com/github/thundermarket/thundermarket/repository/ProductRepository.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/repository/ProductRepository.java
@@ -23,4 +23,6 @@ public interface ProductRepository extends CrudRepository<Product, Long> {
             "AND (:#{#productFilterRequest.purchaseDateMin} IS NULL OR pd.purchase_date >= :#{#productFilterRequest.purchaseDateMin}) " +
             "AND (:#{#productFilterRequest.purchaseDateMax} IS NULL OR pd.purchase_date <= :#{#productFilterRequest.purchaseDateMax})")
     List<Product> filterByProductOptions(@Param("productFilterRequest") ProductFilterRequest productFilterRequest);
+
+    List<Product> findByTitleContainingIgnoreCase(String keyword);
 }

--- a/src/main/java/com/github/thundermarket/thundermarket/service/ProductService.java
+++ b/src/main/java/com/github/thundermarket/thundermarket/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.github.thundermarket.thundermarket.service;
 
 import com.github.thundermarket.thundermarket.domain.*;
+import com.github.thundermarket.thundermarket.exception.ResourceNotFoundException;
 import com.github.thundermarket.thundermarket.repository.FileStorage;
 import com.github.thundermarket.thundermarket.repository.ProductDetailRepository;
 import com.github.thundermarket.thundermarket.repository.ProductRepository;
@@ -18,6 +19,8 @@ public class ProductService {
 
     public static final int minPaginationLimit = 1;
     public static final int maxPaginationLimit = 100;
+    public static final int minKeywordLength = 2;
+
     private final ProductRepository productRepository;
     private final ProductDetailRepository productDetailRepository;
     private final FileStorage fileStorage;
@@ -55,5 +58,12 @@ public class ProductService {
 
     public ProductsResponse filter(ProductFilterRequest productFilterRequest) {
         return ProductsResponse.of(productRepository.filterByProductOptions(productFilterRequest));
+    }
+
+    public ProductsResponse searchTitleKeyword(String keyword) {
+        if (keyword.length() < minKeywordLength) {
+            throw new ResourceNotFoundException("Search term requires at least two words");
+        }
+        return ProductsResponse.of(productRepository.findByTitleContainingIgnoreCase(keyword));
     }
 }

--- a/src/test/java/com/github/thundermarket/thundermarket/ProductServiceAddTest.java
+++ b/src/test/java/com/github/thundermarket/thundermarket/ProductServiceAddTest.java
@@ -20,6 +20,7 @@ public class ProductServiceAddTest {
     public Product createProduct() {
         return new Product.Builder()
                 .withId(1L)
+                .withTitle("아이폰 팝니다")
                 .withName("iPhone12")
                 .withPrice(200_000)
                 .withStatus("판매중")

--- a/src/test/java/com/github/thundermarket/thundermarket/ProductServiceTest.java
+++ b/src/test/java/com/github/thundermarket/thundermarket/ProductServiceTest.java
@@ -28,6 +28,7 @@ public class ProductServiceTest {
     public Product createProduct() {
         return new Product.Builder()
                 .withId(1L)
+                .withTitle("아이폰 팝니다")
                 .withName("iPhone12")
                 .withPrice(200_000)
                 .withStatus("판매중")
@@ -79,6 +80,7 @@ public class ProductServiceTest {
         String status2 = "판매중";
         Product product2 = new Product.Builder()
                 .withId(id2)
+                .withTitle("아이폰 팝니다")
                 .withName(name2)
                 .withPrice(price2)
                 .withStatus(status2)
@@ -106,6 +108,7 @@ public class ProductServiceTest {
         String status2 = "판매중";
         Product product2 = new Product.Builder()
                 .withId(id2)
+                .withTitle("아이폰 팝니다")
                 .withName(name2)
                 .withPrice(price2)
                 .withStatus(status2)
@@ -129,6 +132,7 @@ public class ProductServiceTest {
         String status2 = "판매중";
         Product product2 = new Product.Builder()
                 .withId(originalId)
+                .withTitle("아이폰 팝니다")
                 .withName(name2)
                 .withPrice(price2)
                 .withStatus(status2)
@@ -162,6 +166,7 @@ public class ProductServiceTest {
         String status2 = "판매중";
         Product product2 = new Product.Builder()
                 .withId(id2)
+                .withTitle("아이폰 팝니다")
                 .withName(name2)
                 .withPrice(price2)
                 .withStatus(status2)
@@ -227,5 +232,16 @@ public class ProductServiceTest {
         Assertions.assertThat(product.getName()).isEqualTo(name);
         Assertions.assertThat(product.getPrice()).isGreaterThanOrEqualTo(priceMin);
         Assertions.assertThat(product.getPrice()).isLessThanOrEqualTo(priceMax);
+    }
+
+    @Test
+    public void 상품_제목_검색() throws IOException {
+        ProductService productService = new ProductService(productRepository, productDetailFakeRepository, fileStorage);
+        Product product = createProduct();
+        productService.add(product, createProductDetail(), createMockMultipartFile());
+
+        ProductsResponse productsResponse = productService.searchTitleKeyword("팝니다");
+
+        Assertions.assertThat(productsResponse.getProducts().getFirst().getTitle()).isEqualTo(product.getTitle());
     }
 }

--- a/src/test/java/com/github/thundermarket/thundermarket/TestDouble/ProductFakeRepository.java
+++ b/src/test/java/com/github/thundermarket/thundermarket/TestDouble/ProductFakeRepository.java
@@ -2,6 +2,7 @@ package com.github.thundermarket.thundermarket.TestDouble;
 
 import com.github.thundermarket.thundermarket.domain.Product;
 import com.github.thundermarket.thundermarket.domain.ProductFilterRequest;
+import com.github.thundermarket.thundermarket.domain.ProductsResponse;
 import com.github.thundermarket.thundermarket.repository.ProductRepository;
 import org.springframework.data.domain.Pageable;
 
@@ -38,6 +39,13 @@ public class ProductFakeRepository implements ProductRepository {
                 .filter(p -> p.getName().equals(productFilterRequest.getName())
                         && p.getPrice() >= productFilterRequest.getPriceMin()
                         && p.getPrice() <= productFilterRequest.getPriceMax())
+                .toList();
+    }
+
+    @Override
+    public List<Product> findByTitleContainingIgnoreCase(String keyword) {
+        return products.stream()
+                .filter(p -> p.getTitle().toLowerCase().contains(keyword.toLowerCase()))
                 .toList();
     }
 

--- a/src/test/resources/InsertProductAndProductDetail.sql
+++ b/src/test/resources/InsertProductAndProductDetail.sql
@@ -1,6 +1,6 @@
-INSERT INTO `products` (`id`, `name`, `price`, `status`)
+INSERT INTO `products` (`id`, `title`, `name`, `price`, `status`)
 VALUES
-    (1, 'iPhone11', 200000, 'available');
+    (1, '아이폰 팝니다', 'iPhone11', 200000, 'available');
 
 INSERT INTO `productDetails` (`id`, `product_id`, `color`, `product_condition`, `battery_condition`, `camera_condition`, `accessories`, `purchase_date`, `warranty_duration`, `trade_location`, `delivery_fee`, `video_file_path`, `thumbnail_file_path`)
 VALUES

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE users (
 
 CREATE TABLE products (
    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+   title VARCHAR(255) NOT NULL,
    name VARCHAR(255) NOT NULL,
    price int NOT NULL,
    status VARCHAR(255) NOT NULL


### PR DESCRIPTION
## 관련 Issue
[#33](https://github.com/f-lab-edu/thunder-market/issues/33)
</br></br>

## 작업 내용
상품 게시글 제목 검색 기능을 추가하였습니다.
title 필드를 대소문자 없이 검색하며, 2글자 이상 입력이 필요합니다.
</br></br>

## 정상 동작 테스트 방법
```python
curl --location --request GET 'localhost:8080/api/v1/products/keyword' \
--form 'keyword="아이폰"'
```
</br></br>


## 참고(선택 사항)

</br></br>
